### PR TITLE
Fix TypeScript declaration file.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,12 +1,14 @@
-interface Point {
-  x: number,
-  y: number
-}
+declare module 'line-intersect' {
+  interface Point {
+    x: number,
+    y: number
+  }
 
-interface IntersectionCheckResult {
-  type: 'none' | 'parallel' | 'colinear' | 'intersecting',
-  point?: Point
-}
+  interface IntersectionCheckResult {
+    type: 'none' | 'parallel' | 'colinear' | 'intersecting',
+    point?: Point
+  }
 
-declare function checkIntersection(x1: number, y1: number, x2: number, y2: number, x3: number, y3: number, x4: number, y4: number): IntersectionCheckResult;
-declare function colinearPointWithinSegment(pointX: number, pointY: number, startX: number, startY: number, endX: number, endY: number): boolean;
+  function checkIntersection(x1: number, y1: number, x2: number, y2: number, x3: number, y3: number, x4: number, y4: number): IntersectionCheckResult;
+  function colinearPointWithinSegment(pointX: number, pointY: number, startX: number, startY: number, endX: number, endY: number): boolean;
+}


### PR DESCRIPTION
I opened an issue (#1) a couple of days ago regarding a `index.d.ts` file not being included in the published npm package. Even though, it was added to the published version, it still wouldn't compile:
![Screen Shot 2019-10-10 at 12 11 23 PM](https://user-images.githubusercontent.com/26641473/66588338-3d53d900-eb5a-11e9-9de9-210947dd3cb4.png)

In this patch, I'm adding a module declaration, which fixes the problem. With this fix, type-checking is done properly and the app compiles successfully.